### PR TITLE
move TCA related stuff from ext_tables.php to TCA/Overrides/, fixes #17

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,26 @@
+<?php
+
+if (!defined('TYPO3_MODE')) {
+    die('Access denied.');
+}
+
+call_user_func(function () {
+
+    $packageKey = 'beautyofcode';
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+        $packageKey,
+        'Configuration/TypoScript/SyntaxHighlighter/',
+        'beautyOfCode (SyntaxHighlighter)'
+    );
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+        $packageKey,
+        'Configuration/TypoScript/Prism/',
+        'beautyOfCode (Prism)'
+    );
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $packageKey . '/Configuration/TypoScript/pageTsConfig.ts">'
+    );
+});

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,54 @@
+<?php
+
+if (!defined('TYPO3_MODE')) {
+    die('Access denied.');
+}
+
+$packageKey = 'beautyofcode';
+
+$GLOBALS['TCA']['tt_content']['columns']['CType']['config']['items'][] = array(
+    'LLL:EXT:beautyofcode/Resources/Private/Language/locallang_db.xlf:content_element.beautyofcode_contentrenderer',
+    'beautyofcode_contentrenderer',
+    'content-special-html',
+);
+
+$GLOBALS['TCA']['tt_content']['types']['beautyofcode_contentrenderer']['showitem'] = '
+--palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:palette.general;general,
+--palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.header;header,
+--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.plugin,
+pi_flexform,
+bodytext;LLL:EXT:beautyofcode/Resources/Private/Language/locallang_db.xlf:code,
+--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
+--palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.frames;frames,
+--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
+--palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
+--palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
+--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended
+';
+
+$configuration = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['beautyofcode'];
+if (is_string($configuration)) {
+    $configuration = (array)@unserialize($configuration);
+} else {
+    $configuration = array();
+}
+
+if (isset($configuration['enable_t3editor']) && $configuration['enable_t3editor'] == 1 &&
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3editor')
+) {
+    $GLOBALS['TCA']['tt_content']['types']['beautyofcode_contentrenderer']['columnsOverrides'] = array(
+        'bodytext' => array(
+            'config' => array(
+                'format'     => 'mixed',
+                'renderType' => 't3editor',
+            ),
+        ),
+    );
+};
+
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['beautyofcode_contentrenderer'] = 'pi_flexform';
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+    '*',
+    'FILE:EXT:' . $packageKey.  '/Configuration/Flexform/ContentRenderer.xml',
+    'beautyofcode_contentrenderer'
+);

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -5,69 +5,6 @@ if (!defined('TYPO3_MODE')) {
 }
 
 call_user_func(function ($packageKey) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-        $packageKey,
-        'Configuration/TypoScript/SyntaxHighlighter/',
-        'beautyOfCode (SyntaxHighlighter)'
-    );
-
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-        $packageKey,
-        'Configuration/TypoScript/Prism/',
-        'beautyOfCode (Prism)'
-    );
-
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $packageKey . '/Configuration/TypoScript/pageTsConfig.ts">'
-    );
-
-    $GLOBALS['TCA']['tt_content']['columns']['CType']['config']['items'][] = array(
-        'LLL:EXT:beautyofcode/Resources/Private/Language/locallang_db.xlf:content_element.beautyofcode_contentrenderer',
-        'beautyofcode_contentrenderer',
-        'content-special-html',
-    );
-
-    $GLOBALS['TCA']['tt_content']['types']['beautyofcode_contentrenderer']['showitem'] = '
-		--palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:palette.general;general,
-		--palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.header;header,
-        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.plugin,
-            pi_flexform,
-            bodytext;LLL:EXT:beautyofcode/Resources/Private/Language/locallang_db.xlf:code,
-        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
-            --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.frames;frames,
-        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
-            --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
-            --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
-        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended
-    ';
-
-    $configuration = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['beautyofcode'];
-    if (is_string($configuration)) {
-        $configuration = (array)@unserialize($configuration);
-    } else {
-        $configuration = array();
-    }
-
-    if (isset($configuration['enable_t3editor']) && $configuration['enable_t3editor'] == 1 &&
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3editor')
-    ) {
-        $GLOBALS['TCA']['tt_content']['types']['beautyofcode_contentrenderer']['columnsOverrides'] = array(
-            'bodytext' => array(
-                'config' => array(
-                    'format'     => 'mixed',
-                    'renderType' => 't3editor',
-                ),
-            ),
-        );
-    };
-
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['beautyofcode_contentrenderer'] = 'pi_flexform';
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
-        '*',
-        'FILE:EXT:' . $packageKey.  '/Configuration/Flexform/ContentRenderer.xml',
-        'beautyofcode_contentrenderer'
-    );
-
     // Needed to prevent dummy table to be processed when deleting a page in BE
     // See https://github.com/fnagel/beautyofcode/issues/14
     if (TYPO3_MODE !== 'BE') {
@@ -89,5 +26,4 @@ call_user_func(function ($packageKey) {
             ),
         );
     }
-
 }, $_EXTKEY);


### PR DESCRIPTION
Since 8.5 ext_tables.php is not loaded for FE, see https://docs.typo3.org/typo3cms/extensions/core/Changelog/8.5/Breaking-78384-FrontendIgnoresTCAInExtTables.html

This pull request moves this code to TCA/Overrides/<tablename>.php

Only tested in 8.7, but according to the docs it should just work with 7.6 too.
Fixes: #17 